### PR TITLE
Bugfix/junhyxxn

### DIFF
--- a/src/main/java/com/educator/eduo/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/com/educator/eduo/advice/ExceptionControllerAdvice.java
@@ -4,6 +4,8 @@ import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,6 +28,17 @@ public class ExceptionControllerAdvice {
     public ResponseEntity<?> handle409(Exception e) {
         e.printStackTrace();
         return new ResponseEntity<>("이미 가입된 회원입니다.", HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<?> handle401(Exception e) {
+        e.printStackTrace();
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<?> handle403(Exception e) {
+        e.printStackTrace();
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/educator/eduo/config/SecurityConfig.java
+++ b/src/main/java/com/educator/eduo/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                        .disable()
                    .exceptionHandling()
                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-                       .accessDeniedHandler(jwtAccessDeniedHandler)
+                       .accessDeniedHandler(jwtAccessDeniedHandler) // 생략해도 AdviceController에서 잡아주기 때문에 괜찮습니다.
                    .and()
                    .sessionManagement()
                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/educator/eduo/security/TokenProvider.java
+++ b/src/main/java/com/educator/eduo/security/TokenProvider.java
@@ -44,8 +44,8 @@ public class TokenProvider implements InitializingBean {
             @Value("${jwt.refreshtoken-validity-in-seconds}") long refreshTokenValidityInMilliSeconds
     ) {
         this.secret = secret;
-        this.accessTokenValidityInMilliSeconds = accessTokenValidityInMilliSeconds*1000;
-        this.refreshTokenValidityInMilliSeconds = refreshTokenValidityInMilliSeconds*1000;
+        this.accessTokenValidityInMilliSeconds = accessTokenValidityInMilliSeconds;
+        this.refreshTokenValidityInMilliSeconds = refreshTokenValidityInMilliSeconds;
     }
 
     @Override


### PR DESCRIPTION
### 주요 버그 수정 

---

- token 만료시간 오류 수정 ( ms 계산이 중복되어 들어감 )

---

#### 💣  중요 Issue 

- Security 도입하여 Filter에서 AccessDeniedException, BadCredentialException이 처리 될 것으로 기대
- 기존 코드에서는 정상적으로 동작
- AdviceController 도입 후 위 2개의 Exception이 500으로 처리되는 현상 발생
- 🌊 Dispatcher Servlet을 지나 Controller로 들어온 요청이기 때문에 AdviceController를 거쳤고, Exception, RuntimeException을 처리하는 메소드에 의해 500으로 처리되었습니다.
- 기존에는 위 과정을 거치지 않고 다시 Security Filter가 동작되면서 처리되었지만 AdviceController로 인해 에러가 제대로 잡히지 않았습니다.
- 따라서, AdviceController에서 AccessDeniedException, BadCredentialException을 처리해주는 method를 추가했습니다.
 